### PR TITLE
Make the examples runnable in the refactored code

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -27,7 +27,7 @@ pathway between the receptors and transcription factors.
 To run PathLinker on this network, use the command:
 (assuming the example directory is the working directory)
 
-    python ../PathLinker.py sample-in-net.txt sample-in-nodetypes.txt
+    python ../run.py sample-in-net.txt sample-in-nodetypes.txt
 
 This will create a file, `out_k_100-ranked-edges.txt`, which ranks the
 interactions (edges) as described above. Some edges are not listed in
@@ -58,7 +58,7 @@ but lacks weights.
 To run PathLinker with PageRank on this network, use the command:
 (assuming the example directory is the working directory)
 
-    python ../PathLinker.py --PageRank sample-in-net-noweights.txt sample-in-nodetypes.txt
+    python ../run.py --PageRank sample-in-net-noweights.txt sample-in-nodetypes.txt
 
 ### Running PageRank
 

--- a/run.py
+++ b/run.py
@@ -174,10 +174,10 @@ REQUIRED arguments:
         writePageRankWeights(prFinal,filename='%s-node-pagerank.txt' % (opts.output))
 
         # Weight the edges by the flux from the nodes
-        calculateFluxEdgeWeights(net, prFinal)
+        pl.calculateFluxEdgeWeights(net, prFinal)
 
         # Write edge fluxes
-        printEdgeFluxes('%s-edge-fluxes.txt' % (opts.output), net)
+        pl.printEdgeFluxes('%s-edge-fluxes.txt' % (opts.output), net)
     
     ## Prepare the network to run KSP
 


### PR DESCRIPTION
@mitchwagner the refactoring in 2c4463c791756ab5d5e3b1b1430619d089315265 broke some of the examples.  With these small changes, I'm able to run them again.